### PR TITLE
fix: sql query statement update in fetchTopFaqs() function

### DIFF
--- a/src/db_interface/faq.ts
+++ b/src/db_interface/faq.ts
@@ -93,12 +93,16 @@ WHERE id IN (${placeholders});
   }
 }
 
+// WHERE created_at >= NOW() - INTERVAL 1 MONTH
 export async function fetchTopFaqs(conn: PoolConnection, limit: number) {
   try {
     const [rows] = await conn.query<RowDataPacket[]>(
       `
-SELECT * FROM faqs
-ORDER BY updated_by DESC
+SELECT faq_id, COUNT(*) AS count
+FROM question_logs
+WHERE created_at >= NOW() - INTERVAL 1 MONTH
+GROUP BY faq_id
+ORDER BY count DESC
 LIMIT ?;
       `,
       [limit]


### PR DESCRIPTION
간단하게 fetchTopFaqs() 함수의 sql query문만 변경했습니다.

- 기존: udpated_by를 내림차순으로 정렬한 순서로 쿼리

- 수정: question_logs  테이블에서 1달 이내에 찍힌 로그를 기준으로, faq_id의 개수를 세서 내림차순으로 정렬, 
limit 개수만큼 자주 묻는 질문을 받아오도록 쿼리

다만, 내 로컬에 찍혀있는 쿼리가 없어서 테스트는 제대로 수행해보지 못함 ..